### PR TITLE
Move `@types` dependency to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/indutny/llparse-builder#readme",
   "devDependencies": {
+    "@types/debug": "4.1.5  ",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.8",
     "mocha": "^8.1.3",
@@ -41,7 +42,6 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@types/debug": "4.1.5  ",
     "binary-search": "^1.3.6",
     "debug": "^4.2.0"
   }


### PR DESCRIPTION
`@types/*` should be a non-devDependency when you export types from within, but since that doesn't happen for `debug`, it seems to be fine to make it a devDependency